### PR TITLE
fixed 'skip' error

### DIFF
--- a/fcp_2_5_checkpoint.m
+++ b/fcp_2_5_checkpoint.m
@@ -143,6 +143,7 @@ for ss = rangeOFsubj
         save([ssSubjPath(ss) '/' fcp2_output.preprocessedData_cfg],'data','-v7.3');
         close all
     else % skip = 1, aka no bad components, re-save 
+        fcp2_output.bad_comp{ss,1} = bad_comp; % write "skip" in output to show no bad components were detected
         data            = data_noisecorr;
         save([ssSubjPath(ss) '/' fcp2_output.preprocessedData_cfg],'data','-v7.3');
         close all


### PR DESCRIPTION
- altered fcp2_5 such that if 'skip' is entered for all three participants, the pipeline doesn't error out. Instead, 'skip' is printed as the output in the fcp2_5 output in "bad_comp"