### PR TITLE
editing char encoding condition

### DIFF
--- a/functions/path_generation.m
+++ b/functions/path_generation.m
@@ -66,10 +66,12 @@ else % otherwise, define the rest of the paths struct
     all_participants = glob([paths.rawmri '/*.mri']);
     pids = cell(length(all_participants),1);
     for ii = 1:length(all_participants)
-        if (length(strfind(all_participants{ii}, '_')) > 1) || (length(strfind(all_participants{ii}, '.')) > 1) 
+        startpos = find(all_participants{ii} == '/', 1, 'last');
+        all_participants_subset = extractAfter(all_participants{ii}, startpos);
+        if (length(strfind(all_participants_subset, '_')) > 1) || (length(strfind(all_participants_subset, '.')) > 1) 
             warning('incorrect PID format: more than one underscore or period was found') % throw an error if PID format is wrong
         else
-            startpos = find(all_participants{ii} == '/', 1, 'last'); % find position of the last '/' to be used for PID extraction
+            % startpos = find(all_participants{ii} == '/', 1, 'last'); % find position of the last '/' to be used for PID extraction
             if contains(all_participants{ii}, '_') % check whether the character array contains an underscore 
                 extracted_pid = extractBetween(all_participants{ii}, startpos+1, '_'); % extract characters between the last '/' and '_'
             else


### PR DESCRIPTION
- previous char encoding looking for multiple underscores in the entire file path (e.g. SoT_TP cause issues). This just checks for after the last / (e.g. ST01_V1.mri)